### PR TITLE
Add more link icons to profile page

### DIFF
--- a/frontend/src/components/GoldberriesComponents.jsx
+++ b/frontend/src/components/GoldberriesComponents.jsx
@@ -41,8 +41,18 @@ import {
   faPersonDrowning,
   faQuestionCircle,
   faShield,
+  faTrophy
 } from "@fortawesome/free-solid-svg-icons";
-import { faDiscord, faTwitch, faYoutube } from "@fortawesome/free-brands-svg-icons";
+import {
+  faDiscord,
+  faTwitch,
+  faYoutube,
+  faSteam,
+  faXTwitter,
+  faGithub,
+  faInstagram,
+  faReddit
+} from "@fortawesome/free-brands-svg-icons";
 import { useTheme } from "@emotion/react";
 import { useAppSettings } from "../hooks/AppSettingsProvider";
 import { getQueryData, useGetPlayerSubmissions } from "../hooks/useApi";
@@ -720,6 +730,13 @@ const LINK_ICONS = {
   youtube: { icon: faYoutube, color: "red", identifier: ["youtu.be/", "youtube.com/"] },
   twitch: { icon: faTwitch, color: "purple", identifier: ["twitch.tv/"] },
   discord: { icon: faDiscord, color: "#5460ef", identifier: ["discord.gg/"] },
+  twitter: { icon: faXTwitter, color: "black", identifier: ["twitter.com/", "x.com/"] },
+  github: { icon: faGithub, color: "#161414", identifier: ["github.com/"] },
+  // instagram has a complicated gradient logo, not sure if this is possible/worth the effort
+  instagram: { icon: faInstagram, color: "#ff2083", identifier: ["instagram.com/"] },
+  speedrun: { icon: faTrophy, color: "#ffcf33", identifier: ["speedrun.com/"] },
+  reddit: { icon: faReddit, color: "#ff4500", identifier: ["reddit.com/"] },
+  steam: { icon: faSteam, color: "#1e3050", identifier: ["steamcommunity.com/", "steampowered.com/"] },
 };
 export function LinkIcon({ url }) {
   const theme = useTheme();

--- a/frontend/src/components/GoldberriesComponents.jsx
+++ b/frontend/src/components/GoldberriesComponents.jsx
@@ -730,13 +730,13 @@ const LINK_ICONS = {
   youtube: { icon: faYoutube, color: "red", identifier: ["youtu.be/", "youtube.com/"] },
   twitch: { icon: faTwitch, color: "purple", identifier: ["twitch.tv/"] },
   discord: { icon: faDiscord, color: "#5460ef", identifier: ["discord.gg/"] },
-  twitter: { icon: faXTwitter, color: "black", identifier: ["twitter.com/", "x.com/"] },
-  github: { icon: faGithub, color: "#161414", identifier: ["github.com/"] },
-  // instagram has a complicated gradient logo, not sure if this is possible/worth the effort
+  twitter: { icon: faXTwitter, color: "black", darkModeColor: "white", identifier: ["twitter.com/", "x.com/"] },
+  github: { icon: faGithub, color: "#161414", darkModeColor: "white", identifier: ["github.com/"] },
   instagram: { icon: faInstagram, color: "#ff2083", identifier: ["instagram.com/"] },
   speedrun: { icon: faTrophy, color: "#ffcf33", identifier: ["speedrun.com/"] },
   reddit: { icon: faReddit, color: "#ff4500", identifier: ["reddit.com/"] },
-  steam: { icon: faSteam, color: "#1e3050", identifier: ["steamcommunity.com/", "steampowered.com/"] },
+  steam: { icon: faSteam, color: "#1e3050", darkModeColor: "white",
+    identifier: ["steamcommunity.com/", "steampowered.com/"] },
 };
 export function LinkIcon({ url }) {
   const theme = useTheme();
@@ -751,7 +751,9 @@ export function LinkIcon({ url }) {
   let linkIconElement = null;
   for (const [key, value] of Object.entries(LINK_ICONS)) {
     if (value.identifier.some((i) => url.includes(i))) {
-      linkIconElement = <FontAwesomeIcon icon={value.icon} color={value.color} />;
+      linkIconElement = <FontAwesomeIcon icon={value.icon}
+                                         color={theme.palette.mode === "dark" && value.darkModeColor ?
+                                             value.darkModeColor : value.color} />;
       break;
     }
   }


### PR DESCRIPTION
This addresses issue https://github.com/yoshiyoshyosh/goldberries/issues/68. Simple change that adds some more link icons for different kinds of links: Twitter/X, GitHub, Instagram, Speedrun.com, Reddit, and Steam.

Example of all the icons, existing and new:
![image](https://github.com/user-attachments/assets/03a8a5e3-e8c1-419a-8972-9aca21295064)
In dark mode:
![image](https://github.com/user-attachments/assets/a21912ff-adba-4646-911e-80eb6c4c0520)

Some darker icons (namely X, GitHub, and Steam) didn't look good in dark mode with their default color, so I added an optional attribute `darkModeColor` that is used if it is specified and if the page is in dark mode (otherwise, it just uses the `color` attribute).

Small note: Instagram has a complicated color gradient for their logo, but the current code structure only supports single-color icons. I didn't think this would be worth the effort at the moment, so I just went with a pink-ish color.